### PR TITLE
Add simple GUI for todo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # codextest
 
-This repository contains a simple todo CLI example.
+This repository contains a simple todo application. You can use it via the
+command line or with a small graphical interface.
 
 ## Usage
 
@@ -14,4 +15,12 @@ List tasks:
 
 ```bash
 python3 main.py list
+```
+
+## GUI
+
+Run the graphical interface:
+
+```bash
+python3 gui.py
 ```

--- a/gui.py
+++ b/gui.py
@@ -1,0 +1,48 @@
+import tkinter as tk
+from tkinter import messagebox
+from todo import add_task, get_tasks
+
+
+def refresh_tasks(listbox: tk.Listbox):
+    listbox.delete(0, tk.END)
+    for task in get_tasks():
+        listbox.insert(tk.END, task)
+
+
+def on_add(entry: tk.Entry, listbox: tk.Listbox):
+    task = entry.get().strip()
+    if not task:
+        messagebox.showwarning("No task", "Please enter a task description")
+        return
+    add_task(task)
+    entry.delete(0, tk.END)
+    refresh_tasks(listbox)
+
+
+def main():
+    root = tk.Tk()
+    root.title("Todo List")
+
+    frame = tk.Frame(root)
+    frame.pack(padx=10, pady=10)
+
+    entry = tk.Entry(frame, width=40)
+    entry.pack(side=tk.LEFT)
+
+    listbox = tk.Listbox(root, width=50)
+    listbox.pack(padx=10, pady=(5, 10))
+
+    add_button = tk.Button(
+        frame,
+        text="Add",
+        command=lambda: on_add(entry, listbox)
+    )
+    add_button.pack(side=tk.LEFT, padx=(5, 0))
+
+    refresh_tasks(listbox)
+
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import argparse
 from todo import add_task, list_tasks
+from gui import main as gui_main
 
 
 def main():
@@ -10,6 +11,7 @@ def main():
     add_parser.add_argument('task', help='Task description')
 
     subparsers.add_parser('list', help='List tasks')
+    subparsers.add_parser('gui', help='Launch the graphical interface')
 
     args = parser.parse_args()
 
@@ -17,6 +19,8 @@ def main():
         add_task(args.task)
     elif args.command == 'list':
         list_tasks()
+    elif args.command == 'gui' or args.command is None:
+        gui_main()
     else:
         parser.print_help()
 

--- a/todo.py
+++ b/todo.py
@@ -18,7 +18,13 @@ def add_task(task):
     tasks.append(task)
     save_tasks(tasks)
 
+def get_tasks():
+    """Return the list of tasks from the data file."""
+    return load_tasks()
+
+
 def list_tasks():
-    tasks = load_tasks()
+    """Print the list of saved tasks to the console."""
+    tasks = get_tasks()
     for i, task in enumerate(tasks, 1):
         print(f"{i}. {task}")


### PR DESCRIPTION
## Summary
- add a Tkinter-based GUI (`gui.py`)
- integrate GUI option into `main.py`
- extend `todo.py` with `get_tasks` helper
- document GUI usage in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py') gui.py`


------
https://chatgpt.com/codex/tasks/task_e_684176abbe9883328b583cfae5847127